### PR TITLE
chore(testing): Update coverage report path in GitHub Actions workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,7 @@ jobs:
         uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: coverage
+          coverage-reports: coverage/clover.xml
   deno:
     name: Deno
     needs: lints


### PR DESCRIPTION
Changed the coverage report path to use `coverage/clover.xml` in the Codacy coverage reporter action. This ensures the correct coverage report is used for analysis, improving the accuracy of reporting in Codacy.

## Summary by Sourcery

CI:
- Update the coverage report path in the GitHub Actions workflow to use 'coverage/clover.xml' for the Codacy coverage reporter action.