### PR TITLE
chore(workflow): skip coverage update on renovate actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,7 @@ jobs:
           GOOGLE_SAFE_BROWSING_API_KEY: ${{ secrets.GOOGLE_SAFE_BROWSING_API_KEY }}
       - name: Update coverage report
         uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699
+        if: ${{ github.actor != 'renovate[bot]' }}
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: coverage/clover.xml


### PR DESCRIPTION
Add a conditional check to the coverage report step to skip execution if the actor is 'renovate[bot]'. This prevents unnecessary updates to coverage reports during automated dependency updates, ensuring the focus remains on impactful changes.

## Summary by Sourcery

CI:
- Add a conditional check to skip the coverage report update if the actor is 'renovate[bot]'.