### PR TITLE
chore(testing): Add TEST_ANALYTICS check and switch to Codecov uploads

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,12 +86,18 @@ jobs:
         run: pnpm test -- --coverage.enabled
         env:
           GOOGLE_SAFE_BROWSING_API_KEY: ${{ secrets.GOOGLE_SAFE_BROWSING_API_KEY }}
-      - name: Update coverage report
-        uses: codacy/codacy-coverage-reporter-action@a38818475bb21847788496e9f0fddaa4e84955ba
+          TEST_ANALYTICS: 1
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@015f24e6818733317a2da2edd6290ab26238649a
         if: ${{ github.actor != 'renovate[bot]' }}
         with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: coverage/clover.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload test results to Codecov
+        if: ${{ github.actor != 'renovate[bot]' && !cancelled() }}
+        uses: codecov/test-results-action@9739113ad922ea0a9abb4b2c0f8bf6a4aa8ef820
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: 'coverage/junit.xml'
   deno:
     name: Deno
     needs: lints

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,7 +17,10 @@ export default defineConfig({
       reporter: process.env.CI ? ['clover'] : coverageConfigDefaults.reporter,
     },
     reporters: process.env.CI
-      ? ['dot', 'github-actions']
+      ? process.env.TEST_ANALYTICS
+        ? ['junit', 'dot', 'github-actions']
+        : ['dot', 'github-actions']
       : configDefaults.reporters,
+    outputFile: 'coverage/junit.xml',
   },
 })


### PR DESCRIPTION
In `vitest.config.ts`, added conditional logic to use JUnit reporting when `TEST_ANALYTICS` is set, and specified an output file for the JUnit report. In the GitHub Actions workflow, switched from Codacy to Codecov for uploading coverage reports and added a step to upload test results with JUnit output. These updates aim to improve test analytics and integration with Codecov.

## Summary by Sourcery

Improve test analytics by switching from Codacy to Codecov for coverage uploads and adding JUnit test result uploads. Update vitest.config.ts to conditionally use JUnit reporting based on TEST_ANALYTICS environment variable.

Enhancements:
- Add conditional logic in vitest.config.ts to use JUnit reporting when TEST_ANALYTICS is set.

CI:
- Switch from Codacy to Codecov for uploading coverage reports in the GitHub Actions workflow.
- Add a step to upload test results with JUnit output to Codecov in the GitHub Actions workflow.