### PR TITLE
chore(testing): Switch coverage reporting from Codecov to SonarCloud

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,7 +91,7 @@ jobs:
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@383f7e52eae3ab0510c3cb0e7d9d150bbaeab838
         env:
-          SONAR_TOKEN: ${{ secrets. SONARCLOUD_TOKEN }}
+          SONAR_TOKEN: ${{ secrets. SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   deno:
     name: Deno

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,8 @@ jobs:
         run: pnpm test -- --coverage.enabled
         env:
           GOOGLE_SAFE_BROWSING_API_KEY: ${{ secrets.GOOGLE_SAFE_BROWSING_API_KEY }}
-          TEST_ANALYTICS: 1
+      - name: Run ESLint
+        run: pnpm test:eslint
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@383f7e52eae3ab0510c3cb0e7d9d150bbaeab838
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,6 +73,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup pnpm
         uses: pnpm/action-setup@ac5bf11548bf5e19b8aadb8182072616590fa4a6
       - name: Set up Node.js

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,8 +67,8 @@ jobs:
         run: pnpm test -- --environment=edge-runtime
         env:
           GOOGLE_SAFE_BROWSING_API_KEY: ${{ secrets.GOOGLE_SAFE_BROWSING_API_KEY }}
-  coverage:
-    name: Coverage
+  analytics:
+    name: Analytics
     needs: [node, edge]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,17 +87,11 @@ jobs:
         env:
           GOOGLE_SAFE_BROWSING_API_KEY: ${{ secrets.GOOGLE_SAFE_BROWSING_API_KEY }}
           TEST_ANALYTICS: 1
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@015f24e6818733317a2da2edd6290ab26238649a
-        if: ${{ github.actor != 'renovate[bot]' }}
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-      - name: Upload test results to Codecov
-        if: ${{ github.actor != 'renovate[bot]' && !cancelled() }}
-        uses: codecov/test-results-action@6515afe67c25cf11657e6eb2dd44cc0b032c8883
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: 'coverage/junit.xml'
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@383f7e52eae3ab0510c3cb0e7d9d150bbaeab838
+        env:
+          SONAR_TOKEN: ${{ secrets. SONARCLOUD_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   deno:
     name: Deno
     needs: lints

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ node_modules/
 # environment variables
 .env*
 
-# testing
+# reports
 coverage
+lints

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # google-safe-browsing [![JSR](https://jsr.io/badges/@hckhanh/google-safe-browsing)](https://jsr.io/@hckhanh/google-safe-browsing)
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=hckhanh_google-safe-browsing&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=hckhanh_google-safe-browsing)
-[![codecov](https://codecov.io/gh/hckhanh/google-safe-browsing/graph/badge.svg?token=OTWNSODDXK)](https://codecov.io/gh/hckhanh/google-safe-browsing)
 
 A JavaScript client for [Google Safe Browsing](https://safebrowsing.google.com) [API](https://developers.google.com/safe-browsing)
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "test": "vitest related src/*.ts",
     "test:prettier": "prettier --check .",
-    "test:types": "deno check src/index.ts"
+    "test:types": "deno check src/index.ts",
+    "test:eslint": "eslint . -f json -o lints/eslint-report.json"
   },
   "author": {
     "name": "Khánh Hoàng",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.projectKey=hckhanh_google-safe-browsing
+sonar.organization=hckhanh
+
+sonar.javascript.lcov.reportPaths=./coverage/lcov.info
+sonar.eslint.reportPaths=./lints/eslint-report.json

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.projectKey=hckhanh_google-safe-browsing
 sonar.organization=hckhanh
 
-sonar.javascript.lcov.reportPaths=./coverage/lcov.info
-sonar.eslint.reportPaths=./lints/eslint-report.json
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.eslint.reportPaths=lints/eslint-report.json

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,13 +14,10 @@ export default defineConfig({
         '*.config.js',
         ...coverageConfigDefaults.exclude,
       ],
-      reporter: process.env.CI ? ['clover'] : coverageConfigDefaults.reporter,
+      reporter: process.env.CI ? ['lcovonly'] : coverageConfigDefaults.reporter,
     },
     reporters: process.env.CI
-      ? process.env.TEST_ANALYTICS
-        ? ['junit', 'dot', 'github-actions']
-        : ['dot', 'github-actions']
+      ? ['dot', 'github-actions']
       : configDefaults.reporters,
-    outputFile: 'coverage/junit.xml',
   },
 })


### PR DESCRIPTION
Replace Codecov integrations with SonarCloud for coverage reporting and static code analysis. Add `sonar-project.properties` to configure SonarCloud reporting paths. Update GitHub Actions workflow to execute SonarCloud scans, removing Codecov steps.

## Summary by Sourcery

Replace Codecov with SonarCloud for coverage reporting and static code analysis, updating GitHub Actions workflow and configuration files accordingly.

CI:
- Switch from Codecov to SonarCloud for coverage reporting and static code analysis in GitHub Actions workflow.

Documentation:
- Remove Codecov badge from README.md.

Chores:
- Add sonar-project.properties file to configure SonarCloud reporting paths.