### PR TITLE
chore(testing): Configure SonarQube to include TypeScript test files

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,8 +88,10 @@ jobs:
         run: pnpm test -- --coverage.enabled
         env:
           GOOGLE_SAFE_BROWSING_API_KEY: ${{ secrets.GOOGLE_SAFE_BROWSING_API_KEY }}
-      - name: Run ESLint
-        run: pnpm test:eslint
+      - name: Generate ESLint report
+        run: |
+          pnpm test:eslint
+          sed -i 's|${{ github.workspace }}/||g' lints/eslint-report.json
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@383f7e52eae3ab0510c3cb0e7d9d150bbaeab838
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Generate ESLint report
         run: |
           pnpm test:eslint
-          sed -i 's|${{ github.workspace }}/||g' lints/eslint-report.json
+          sed -i 's|${{ github.workspace }}/|/github/workspace/|g' lints/eslint-report.json
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@383f7e52eae3ab0510c3cb0e7d9d150bbaeab838
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,6 +92,14 @@ jobs:
         run: pnpm test:eslint
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@383f7e52eae3ab0510c3cb0e7d9d150bbaeab838
+        with:
+          args: >
+            -Dsonar.projectKey=hckhanh_google-safe-browsing
+            -Dsonar.organization=hckhanh
+            -Dsonar.sources=.
+            -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
+            -Dsonar.eslint.reportPaths=lints/eslint-report.json
+            -Dsonar.test.inclusions=src/**/*.test.ts
         env:
           SONAR_TOKEN: ${{ secrets. SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,17 +91,9 @@ jobs:
       - name: Generate ESLint report
         run: |
           pnpm test:eslint
-          sed -i 's|${{ github.workspace }}/|/github/workspace/|g' lints/eslint-report.json
+          sed -i 's|${{ github.workspace }}/||g' lints/eslint-report.json
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@383f7e52eae3ab0510c3cb0e7d9d150bbaeab838
-        with:
-          args: >
-            -Dsonar.projectKey=hckhanh_google-safe-browsing
-            -Dsonar.organization=hckhanh
-            -Dsonar.sources=.
-            -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
-            -Dsonar.eslint.reportPaths=lints/eslint-report.json
-            -Dsonar.test.inclusions=src/**/*.test.ts
         env:
           SONAR_TOKEN: ${{ secrets. SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "vitest related src/*.ts",
     "test:prettier": "prettier --check .",
     "test:types": "deno check src/index.ts",
-    "test:eslint": "eslint . -f json -o lints/eslint-report.json"
+    "test:eslint": "eslint src/ -f json -o lints/eslint-report.json"
   },
   "author": {
     "name": "Khánh Hoàng",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,0 @@
-sonar.projectKey=hckhanh_google-safe-browsing
-sonar.organization=hckhanh
-
-sonar.javascript.lcov.reportPaths=coverage/lcov.info
-sonar.eslint.reportPaths=lints/eslint-report.json
-sonar.test.inclusions=src/**/*.test.ts

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,9 +1,11 @@
 sonar.projectKey=hckhanh_google-safe-browsing
 sonar.organization=hckhanh
 
-sonar.javascript.lcov.reportPaths=coverage/lcov.info
-sonar.eslint.reportPaths=lints/eslint-report.json
 sonar.sources=src/
 sonar.exclusions=src/**/*.test.ts
+
 sonar.tests=src/
 sonar.test.inclusions=src/**/*.test.ts
+
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.eslint.reportPaths=lints/eslint-report.json

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,3 +3,4 @@ sonar.organization=hckhanh
 
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.eslint.reportPaths=lints/eslint-report.json
+sonar.test.inclusions=src/**/*.test.ts

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,9 @@
+sonar.projectKey=hckhanh_google-safe-browsing
+sonar.organization=hckhanh
+
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.eslint.reportPaths=lints/eslint-report.json
+sonar.sources=src/
+sonar.exclusions=src/**/*.test.ts
+sonar.tests=src/
+sonar.test.inclusions=src/**/*.test.ts


### PR DESCRIPTION
Added a configuration to include TypeScript test files located in the `src` directory for SonarQube analysis. This change helps in capturing and analyzing test-specific metrics to enhance code quality assessments.

## Summary by Sourcery

CI:
- Configure SonarQube to include TypeScript test files located in the src directory for analysis.