### PR TITLE
chore(testing): Simplify ESLint report generation process

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,9 +89,7 @@ jobs:
         env:
           GOOGLE_SAFE_BROWSING_API_KEY: ${{ secrets.GOOGLE_SAFE_BROWSING_API_KEY }}
       - name: Generate ESLint report
-        run: |
-          pnpm test:eslint
-          sed -i 's|${{ github.workspace }}/||g' lints/eslint-report.json
+        run: pnpm test:eslint
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@9f9bba2c7aaf7a55eac26abbac906c3021d211b2
         env:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "vitest related src/*.ts",
     "test:prettier": "prettier --check .",
     "test:types": "deno check src/index.ts",
-    "test:eslint": "eslint src/ -f json -o lints/eslint-report.json"
+    "test:eslint": "eslint src/ -f json -o eslint-report.json"
   },
   "author": {
     "name": "Khánh Hoàng",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,4 +8,4 @@ sonar.tests=src/
 sonar.test.inclusions=src/**/*.test.ts
 
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
-sonar.eslint.reportPaths=lints/eslint-report.json
+sonar.eslint.reportPaths=eslint-report.json


### PR DESCRIPTION
Removed redundant sed command from the ESLint report generation step in GitHub workflows. Updated the output path of the ESLint report in package.json for consistency. These changes streamline the ESLint reporting process and maintain cleaner file paths.

## Summary by Sourcery

Simplify the ESLint report generation process by removing an unnecessary sed command from the GitHub workflow and updating the report output path in package.json for consistency.

Build:
- Update the output path of the ESLint report in package.json for consistency.

Chores:
- Remove redundant sed command from the ESLint report generation step in GitHub workflows.